### PR TITLE
See product in 3D

### DIFF
--- a/app/src/main/java/com/userapp/MainActivity.kt
+++ b/app/src/main/java/com/userapp/MainActivity.kt
@@ -65,7 +65,10 @@ class MainActivity : ComponentActivity() {
                     arguments = listOf(navArgument("productId") { type = NavType.StringType })
                 ) { backStackEntry ->
                     val productId = backStackEntry.arguments?.getString("productId") ?: ""
-                    Model3DScreen(productId)
+                    Model3DScreen(
+                        productId,
+                        navController = navController,
+                    )
                 }
 
                 composable(Screen.Favorites.route) {

--- a/app/src/main/java/com/userapp/view/components/ar/CenterCard.kt
+++ b/app/src/main/java/com/userapp/view/components/ar/CenterCard.kt
@@ -1,4 +1,4 @@
-package com.userapp.view.components
+package com.userapp.view.components.ar
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/userapp/view/components/navbar/BottomNavItem.kt
+++ b/app/src/main/java/com/userapp/view/components/navbar/BottomNavItem.kt
@@ -1,4 +1,4 @@
-package com.userapp.view.components
+package com.userapp.view.components.navbar
 
 data class BottomNavItem(
     val route: String,

--- a/app/src/main/java/com/userapp/view/components/navbar/BottomNavigationBar.kt
+++ b/app/src/main/java/com/userapp/view/components/navbar/BottomNavigationBar.kt
@@ -1,4 +1,4 @@
-package com.userapp.view.components
+package com.userapp.view.components.navbar
 
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar

--- a/app/src/main/java/com/userapp/view/components/navbar/TopBar.kt
+++ b/app/src/main/java/com/userapp/view/components/navbar/TopBar.kt
@@ -1,4 +1,4 @@
-package com.userapp.view.components
+package com.userapp.view.components.navbar
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/app/src/main/java/com/userapp/view/components/product/FullScreenImageViewer.kt
+++ b/app/src/main/java/com/userapp/view/components/product/FullScreenImageViewer.kt
@@ -1,84 +1,88 @@
-package com.userapp.view.components
+package com.userapp.view.components.product
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import coil.compose.rememberAsyncImagePainter
+import com.userapp.R
 
 @Composable
-fun ImageCarousel(
+fun FullscreenImageViewer(
     images: List<String>,
+    initialPage: Int,
     productName: String,
-    onImageClick: (index: Int) -> Unit
+    onDismiss: () -> Unit
 ) {
-    if (images.isEmpty()) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1.6f)
-                .background(Color.LightGray),
-            contentAlignment = Alignment.Center
-        ) {
-            Text("No images", color = Color.DarkGray)
-        }
-        return
-    }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .zIndex(1f)
+            .systemBarsPadding()
+    ) {
+        val fullScreenPagerState = rememberPagerState(
+            initialPage = initialPage,
+            pageCount = { images.size }
+        )
 
-    val pagerState = rememberPagerState(initialPage = 0) { images.size }
-
-    Column {
         HorizontalPager(
-            state = pagerState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable {
-                    onImageClick(pagerState.currentPage)
-                }
+            state = fullScreenPagerState,
+            modifier = Modifier.fillMaxSize()
         ) { page ->
             Image(
                 painter = rememberAsyncImagePainter(images[page]),
                 contentDescription = productName,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(1.6f)
-                    .clip(RoundedCornerShape(12.dp)),
-                contentScale = ContentScale.Crop
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+
+        IconButton(
+            onClick = onDismiss,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(16.dp)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.baseline_arrow_back_24),
+                contentDescription = "Go Back",
+                tint = Color.White
             )
         }
 
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 8.dp),
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 16.dp),
             horizontalArrangement = Arrangement.Center
         ) {
             repeat(images.size) { index ->
-                val color = if (pagerState.currentPage == index) Color.Gray else Color.LightGray
+                val color = if (fullScreenPagerState.currentPage == index) Color.White else Color.Gray
                 Box(
                     modifier = Modifier
                         .padding(2.dp)
-                        .size(8.dp)
+                        .size(10.dp)
                         .clip(CircleShape)
                         .background(color)
                 )

--- a/app/src/main/java/com/userapp/view/components/product/ImageCarrousel.kt
+++ b/app/src/main/java/com/userapp/view/components/product/ImageCarrousel.kt
@@ -1,88 +1,84 @@
-package com.userapp.view.components
+package com.userapp.view.components.product
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBarsPadding
 
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import coil.compose.rememberAsyncImagePainter
-import com.userapp.R
 
 @Composable
-fun FullscreenImageViewer(
+fun ImageCarousel(
     images: List<String>,
-    initialPage: Int,
     productName: String,
-    onDismiss: () -> Unit
+    onImageClick: (index: Int) -> Unit
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black)
-            .zIndex(1f)
-            .systemBarsPadding()
-    ) {
-        val fullScreenPagerState = rememberPagerState(
-            initialPage = initialPage,
-            pageCount = { images.size }
-        )
+    if (images.isEmpty()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1.6f)
+                .background(Color.LightGray),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("No images", color = Color.DarkGray)
+        }
+        return
+    }
 
+    val pagerState = rememberPagerState(initialPage = 0) { images.size }
+
+    Column {
         HorizontalPager(
-            state = fullScreenPagerState,
-            modifier = Modifier.fillMaxSize()
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    onImageClick(pagerState.currentPage)
+                }
         ) { page ->
             Image(
                 painter = rememberAsyncImagePainter(images[page]),
                 contentDescription = productName,
-                modifier = Modifier.fillMaxSize()
-            )
-        }
-
-        IconButton(
-            onClick = onDismiss,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .padding(16.dp)
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.baseline_arrow_back_24),
-                contentDescription = "Go Back",
-                tint = Color.White
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1.6f)
+                    .clip(RoundedCornerShape(12.dp)),
+                contentScale = ContentScale.Crop
             )
         }
 
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .align(Alignment.BottomCenter)
-                .padding(bottom = 16.dp),
+                .padding(top = 8.dp),
             horizontalArrangement = Arrangement.Center
         ) {
             repeat(images.size) { index ->
-                val color = if (fullScreenPagerState.currentPage == index) Color.White else Color.Gray
+                val color = if (pagerState.currentPage == index) Color.Gray else Color.LightGray
                 Box(
                     modifier = Modifier
                         .padding(2.dp)
-                        .size(10.dp)
+                        .size(8.dp)
                         .clip(CircleShape)
                         .background(color)
                 )

--- a/app/src/main/java/com/userapp/view/components/product/ProductActions.kt
+++ b/app/src/main/java/com/userapp/view/components/product/ProductActions.kt
@@ -1,4 +1,4 @@
-package com.userapp.view.components
+package com.userapp.view.components.product
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*

--- a/app/src/main/java/com/userapp/view/components/product/ProductCard.kt
+++ b/app/src/main/java/com/userapp/view/components/product/ProductCard.kt
@@ -1,4 +1,4 @@
-package com.userapp.view.components
+package com.userapp.view.components.product
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,11 +14,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
-import com.userapp.R
 import com.userapp.model.ProductItem
 
 @Composable

--- a/app/src/main/java/com/userapp/view/components/product/StaggeredProductsGrid.kt
+++ b/app/src/main/java/com/userapp/view/components/product/StaggeredProductsGrid.kt
@@ -1,4 +1,4 @@
-package com.userapp.view.components
+package com.userapp.view.components.product
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -9,13 +9,9 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.userapp.model.ProductItem
-import com.userapp.viewmodel.favorites.FavoritesViewModel
-import kotlinx.coroutines.launch
 
 @Composable
 fun StaggeredProductGrid(

--- a/app/src/main/java/com/userapp/view/components/search/SearchBar.kt
+++ b/app/src/main/java/com/userapp/view/components/search/SearchBar.kt
@@ -1,4 +1,4 @@
-package com.userapp.view.components
+package com.userapp.view.components.search
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row

--- a/app/src/main/java/com/userapp/view/components/search/SortDialog.kt
+++ b/app/src/main/java/com/userapp/view/components/search/SortDialog.kt
@@ -1,4 +1,4 @@
-package com.userapp.view.components
+package com.userapp.view.components.search
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/userapp/view/screen/ARScreen.kt
+++ b/app/src/main/java/com/userapp/view/screen/ARScreen.kt
@@ -22,7 +22,7 @@ import com.google.ar.core.Config
 import com.google.ar.core.Frame
 import com.google.ar.core.Plane
 import com.google.ar.core.TrackingState
-import com.userapp.view.components.CenterCard
+import com.userapp.view.components.ar.CenterCard
 import com.userapp.viewmodel.ar.Product3DModelViewModel
 import com.userapp.viewmodel.ar.Product3DModelViewModelFactoryProvider
 import com.userapp.viewmodel.uistate.UiState

--- a/app/src/main/java/com/userapp/view/screen/CatalogScreen.kt
+++ b/app/src/main/java/com/userapp/view/screen/CatalogScreen.kt
@@ -1,17 +1,11 @@
 package com.userapp.view.screen
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
-import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
-import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
@@ -24,10 +18,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.userapp.view.components.BottomNavigationBar
-import com.userapp.view.components.ProductCard
-import com.userapp.view.components.StaggeredProductGrid
-import com.userapp.view.components.TopBar
+import com.userapp.view.components.navbar.BottomNavigationBar
+import com.userapp.view.components.product.StaggeredProductGrid
+import com.userapp.view.components.navbar.TopBar
 import com.userapp.viewmodel.catalog.CatalogViewModel
 import com.userapp.viewmodel.uistate.UiState
 

--- a/app/src/main/java/com/userapp/view/screen/FavoritesScreen.kt
+++ b/app/src/main/java/com/userapp/view/screen/FavoritesScreen.kt
@@ -3,11 +3,9 @@ package com.userapp.view.screen
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -18,9 +16,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.userapp.view.components.BottomNavigationBar
-import com.userapp.view.components.StaggeredProductGrid
-import com.userapp.view.components.TopBar
+import com.userapp.view.components.navbar.BottomNavigationBar
+import com.userapp.view.components.product.StaggeredProductGrid
+import com.userapp.view.components.navbar.TopBar
 import com.userapp.viewmodel.favorites.FavoritesViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/userapp/view/screen/Model3DScreen.kt
+++ b/app/src/main/java/com/userapp/view/screen/Model3DScreen.kt
@@ -1,8 +1,118 @@
 package com.userapp.view.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.userapp.viewmodel.ar.Product3DModelViewModel
+import com.userapp.viewmodel.ar.Product3DModelViewModelFactoryProvider
+import dagger.hilt.android.EntryPointAccessors
+import io.github.sceneview.Scene
+import io.github.sceneview.math.Position
+import io.github.sceneview.model.engine
+import io.github.sceneview.node.ModelNode
+import io.github.sceneview.node.Node
+import io.github.sceneview.rememberCameraNode
+import io.github.sceneview.rememberEngine
+import io.github.sceneview.rememberModelLoader
+import io.github.sceneview.rememberView
 
 @Composable
-fun Model3DScreen(productId: String) {
+fun Model3DScreen(
+    productId: String,
+    navController: NavController
+) {
+    val context = LocalContext.current
+    val factory = remember {
+        EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            Product3DModelViewModelFactoryProvider::class.java
+        ).product3DModelViewModelFactory()
+    }
 
+    val viewModel: Product3DModelViewModel = remember {
+        factory.create(productId)
+    }
+
+    val modelUrl by viewModel.modelUrl.collectAsState()
+
+    val engine = rememberEngine()
+    val view = rememberView(engine)
+    val modelLoader = rememberModelLoader(engine)
+    val cameraNode = rememberCameraNode(engine)
+    val childNodes = remember { mutableStateListOf<Node>() }
+    val isModelLoaded = remember { mutableStateOf(false) }
+
+    LaunchedEffect(modelUrl) {
+        val url = modelUrl
+        if (!url.isNullOrBlank()) {
+            modelLoader.loadModelInstanceAsync(url) { modelInstance ->
+                if (modelInstance != null) {
+                    val modelNode = ModelNode(
+                        modelInstance = modelInstance,
+                        scaleToUnits = 1.0f,
+                    ).apply {
+                        isScaleEditable = false
+                        isPositionEditable = false
+                        isRotationEditable = true
+                    }
+                    childNodes += modelNode
+                    isModelLoaded.value = true
+                }
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Gray)
+    ) {
+        Scene(
+            modifier = Modifier.fillMaxSize(),
+            engine = engine,
+            view = view,
+            cameraNode = cameraNode,
+            childNodes = childNodes,
+        )
+
+        if (!isModelLoaded.value) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = Color.White)
+            }
+        }
+
+        IconButton(
+            onClick = {navController.popBackStack()},
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(16.dp)
+                .statusBarsPadding()
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = Color.White
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/userapp/view/screen/ProductDetailsScreen.kt
+++ b/app/src/main/java/com/userapp/view/screen/ProductDetailsScreen.kt
@@ -27,8 +27,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.userapp.view.components.FullscreenImageViewer
-import com.userapp.view.components.ImageCarousel
+import com.userapp.view.components.product.FullscreenImageViewer
+import com.userapp.view.components.product.ImageCarousel
 import com.userapp.viewmodel.product.ProductDetailsViewModel
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
@@ -50,7 +50,7 @@ import com.userapp.viewmodel.product.ProductDetailsViewModelFactoryProvider
 import com.userapp.viewmodel.uistate.UiState
 import dagger.hilt.android.EntryPointAccessors
 import com.userapp.model.ProductDetails
-import com.userapp.view.components.ProductActions
+import com.userapp.view.components.product.ProductActions
 import com.userapp.viewmodel.favorites.FavoritesViewModel
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/userapp/view/screen/SearchScreen.kt
+++ b/app/src/main/java/com/userapp/view/screen/SearchScreen.kt
@@ -21,10 +21,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.userapp.R
-import com.userapp.view.components.BottomNavigationBar
-import com.userapp.view.components.FilterDialog
-import com.userapp.view.components.SearchBar
-import com.userapp.view.components.StaggeredProductGrid
+import com.userapp.view.components.navbar.BottomNavigationBar
+import com.userapp.view.components.search.FilterDialog
+import com.userapp.view.components.search.SearchBar
+import com.userapp.view.components.product.StaggeredProductGrid
 import com.userapp.viewmodel.search.SearchHistoryViewModel
 import com.userapp.viewmodel.search.SearchViewModel
 import com.userapp.viewmodel.uistate.UiState


### PR DESCRIPTION
This pull request introduces the new 3D Model Viewer screen in the User App. It loads and renders a product’s 3D model from a remote model3DUrl, allowing users to preview the object before entering AR mode.

### Main Changes:

- Created new screen Model3DScreen in the navigation graph.
- Integrated model rendering engine.
- Handled model loading from URL with loading indicator.
- Displayed error message if the model failed to load.
- Connected from product detail screen with proper routing.